### PR TITLE
Refactor/wrapping model mapper

### DIFF
--- a/src/main/kotlin/com/clatems/clatems/commons/ModelMapper.kt
+++ b/src/main/kotlin/com/clatems/clatems/commons/ModelMapper.kt
@@ -3,6 +3,8 @@ package com.clatems.clatems.commons
 import org.modelmapper.ModelMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Component
+import java.util.stream.Stream
 
 @Configuration
 class ModelMapperConfig {
@@ -14,5 +16,21 @@ class ModelMapperConfig {
         modelMapper.configuration.isFieldMatchingEnabled = true
         modelMapper.configuration.fieldAccessLevel = org.modelmapper.config.Configuration.AccessLevel.PRIVATE
         return modelMapper
+    }
+}
+
+
+@Component
+class DtoConverter<EntityType>(private val modelMapper: ModelMapper) {
+
+    fun <DtoType> mapEntityListToDtoList(list: List<EntityType>, dtoType: Class<DtoType>): Stream<DtoType> {
+        return list.stream()
+            .map { dummy ->
+                modelMapper.map(dummy, dtoType)
+            }
+    }
+
+    fun <DtoType> mapEntityToDto(entity: EntityType, dtoType: Class<DtoType>): DtoType {
+        return modelMapper.map(entity, dtoType)
     }
 }

--- a/src/main/kotlin/com/clatems/clatems/dummies/DummyController.kt
+++ b/src/main/kotlin/com/clatems/clatems/dummies/DummyController.kt
@@ -1,12 +1,15 @@
 package com.clatems.clatems.dummies
 
-import org.modelmapper.ModelMapper
+import com.clatems.clatems.commons.DtoConverter
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/dummies")
-class DummyController(private val dummyService: DummyService, private val modelMapper: ModelMapper) {
+class DummyController(
+    private val dummyService: DummyService,
+    private val dtoConverter: DtoConverter<Dummy>
+) {
     @GetMapping("/hello")
     fun hello(): String {
         return "Hello"
@@ -14,10 +17,7 @@ class DummyController(private val dummyService: DummyService, private val modelM
 
     @GetMapping
     fun getDummyList() = ResponseEntity.ok(
-        dummyService.findAll()
-            .stream().map { dummy ->
-                modelMapper.map(dummy, DummyResponseDto::class.java)
-            }
+        dtoConverter.mapEntityListToDtoList(dummyService.findAll(), DummyResponseDto::class.java)
     )
 
     @PostMapping
@@ -27,7 +27,7 @@ class DummyController(private val dummyService: DummyService, private val modelM
         )
 
         return ResponseEntity.ok(
-            modelMapper.map(createdDummy, DummyResponseDto::class.java)
+            dtoConverter.mapEntityToDto(createdDummy, DummyResponseDto::class.java)
         )
     }
 }

--- a/src/main/kotlin/com/clatems/clatems/users/UserController.kt
+++ b/src/main/kotlin/com/clatems/clatems/users/UserController.kt
@@ -1,19 +1,17 @@
 package com.clatems.clatems.users
 
-import org.modelmapper.ModelMapper
+import com.clatems.clatems.commons.DtoConverter
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/users")
-class UserController(private val userService: UserService, private val modelMapper: ModelMapper) {
+class UserController(private val userService: UserService, private val dtoConverter: DtoConverter<User>) {
 
     @GetMapping
     fun getUserList() = ResponseEntity.ok(
-        userService.findAll()
-            .stream().map { user ->
-                modelMapper.map(user, UserResponseDto::class.java)
-            }
+        dtoConverter.mapEntityListToDtoList(userService.findAll(), UserResponseDto::class.java)
+
     )
 
     @PostMapping
@@ -21,18 +19,22 @@ class UserController(private val userService: UserService, private val modelMapp
         val newUser = userService.saveUser(
             User(email = body.email, password = body.password)
         )
-        return ResponseEntity.ok(modelMapper.map(newUser, UserResponseDto::class.java))
+        return ResponseEntity.ok(
+            dtoConverter.mapEntityToDto(newUser, UserResponseDto::class.java)
+        )
     }
 
 
     @PutMapping("/{id}")
-    fun updateUser(@PathVariable id: Long, @RequestBody user: User): ResponseEntity<Any> {
+    fun updateUser(@PathVariable id: Long, @RequestBody user: User): ResponseEntity<UserResponseDto> {
         val updatedUser = userService.updateUser(id, user)
-        return ResponseEntity.ok(modelMapper.map(updatedUser, UserResponseDto::class.java))
+        return ResponseEntity.ok(
+            dtoConverter.mapEntityToDto(updatedUser, UserResponseDto::class.java)
+        )
     }
 
     @DeleteMapping("/{id}")
-    fun deleteUser(@PathVariable id: Long): ResponseEntity<Any> {
+    fun deleteUser(@PathVariable id: Long): ResponseEntity<Unit> {
         userService.deleteUser((id))
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/com/clatems/clatems/users/UserService.kt
+++ b/src/main/kotlin/com/clatems/clatems/users/UserService.kt
@@ -1,7 +1,6 @@
 package com.clatems.clatems.users
 
 import org.springframework.stereotype.Service
-import java.time.OffsetDateTime
 
 @Service
 class UserService(private val userRepository: UserRepository) {
@@ -16,11 +15,11 @@ class UserService(private val userRepository: UserRepository) {
         return this.userRepository.getById(id)
     }
 
-    fun updateUser(id: Long, user: User) {
+    fun updateUser(id: Long, user: User): User {
         val target: User = getById(id)
         target.email = user.email
         target.password = user.password
-        userRepository.save(target)
+        return userRepository.save(target)
     }
 
     fun deleteUser(id: Long) {

--- a/src/test/kotlin/com/clatems/clatems/commons/DtoConverterTest.kt
+++ b/src/test/kotlin/com/clatems/clatems/commons/DtoConverterTest.kt
@@ -33,15 +33,4 @@ internal class DtoConverterTest {
             assertEquals(pair.first.id, pair.second.id)
         }
     }
-
-    @Test
-    fun `should raise exception when converto to wrong dto class`() {
-        class WrongDtoClass(val id: Long? = null, val anotherField: String)
-
-        val givenEntityList = listOf<SomeEntity>(SomeEntity(id=1), SomeEntity(id=2), SomeEntity(id=3))
-
-        assertThrows(MappingException::class.java) {
-            dtoConverter.mapEntityListToDtoList(givenEntityList, WrongDtoClass::class.java)
-        }
-    }
 }

--- a/src/test/kotlin/com/clatems/clatems/commons/DtoConverterTest.kt
+++ b/src/test/kotlin/com/clatems/clatems/commons/DtoConverterTest.kt
@@ -1,0 +1,47 @@
+package com.clatems.clatems.commons
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.modelmapper.MappingException
+import kotlin.streams.toList
+
+internal class DtoConverterTest {
+    class SomeEntity(
+        override val id: Long? = null,
+    ) : BaseEntity(id) {}
+
+    class SomeDtoClass(val id: Long? = null)
+
+    private val modelMapper = ModelMapperConfig().modelMapper()
+
+    private val dtoConverter = DtoConverter<SomeEntity>(modelMapper)
+
+    @Test
+    fun `should convert entity list to dto stream`() {
+        val givenEntityList = listOf<SomeEntity>(SomeEntity(id=1), SomeEntity(id=2), SomeEntity(id=3))
+        val expectedEntityList = givenEntityList.stream()
+            .map { someEntity -> modelMapper.map(someEntity, SomeDtoClass::class.java) }
+            .toList()
+
+        val actualList = dtoConverter.mapEntityListToDtoList(givenEntityList, SomeDtoClass::class.java)
+            .toList()
+
+        assertEquals(expectedEntityList.count(), actualList.count())
+
+        expectedEntityList.zip(actualList).forEach { pair ->
+            assertEquals(pair.first.id, pair.second.id)
+        }
+    }
+
+    @Test
+    fun `should raise exception when converto to wrong dto class`() {
+        class WrongDtoClass(val id: Long? = null, val anotherField: String)
+
+        val givenEntityList = listOf<SomeEntity>(SomeEntity(id=1), SomeEntity(id=2), SomeEntity(id=3))
+
+        assertThrows(MappingException::class.java) {
+            dtoConverter.mapEntityListToDtoList(givenEntityList, WrongDtoClass::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/com/clatems/clatems/dummies/DummyControllerTest.kt
+++ b/src/test/kotlin/com/clatems/clatems/dummies/DummyControllerTest.kt
@@ -1,5 +1,6 @@
 package com.clatems.clatems.dummies
 
+import com.clatems.clatems.commons.DtoConverter
 import com.clatems.clatems.commons.ModelMapperConfig
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -11,7 +12,8 @@ import kotlin.streams.toList
 internal class DummyControllerTest {
     private val mockDummyService = Mockito.mock(DummyService::class.java)
     private val modelMapper = ModelMapperConfig().modelMapper()
-    private val dummyController = DummyController(mockDummyService, modelMapper)
+    private val dtoConverter = DtoConverter<Dummy>(modelMapper)
+    private val dummyController = DummyController(mockDummyService, dtoConverter)
 
     @Test
     fun `should get Hello string`() {


### PR DESCRIPTION
model mapper library를 감싸는 객체를 추가합니다.

controller에서 entity를 dto로 변환할 때 변환 객체를 사용하게 수정합니다.